### PR TITLE
allow epoll setting to be optional based on env

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/spring/boot/SocketioServerAutoConfiguration.java
+++ b/src/main/java/com/corundumstudio/socketio/spring/boot/SocketioServerAutoConfiguration.java
@@ -1,5 +1,6 @@
 package com.corundumstudio.socketio.spring.boot;
 
+import io.netty.channel.epoll.Epoll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -56,6 +57,13 @@ public class SocketioServerAutoConfiguration implements DisposableBean {
 		config.setAuthorizationListener(socketAuthzListener);
 		config.setExceptionListener(exceptionListener);
 		config.setStoreFactory(clientStoreFactory);
+
+		if (config.isUseLinuxNativeEpoll()
+				&& !config.isFailIfNativeEpollLibNotPresent()
+				&& !Epoll.isAvailable()) {
+			LOG.warn("Epoll library not available, disabling native epoll");
+			config.setUseLinuxNativeEpoll(false);
+		}
 
 		final SocketIOServer server = new SocketIOServer(config);
 		

--- a/src/main/java/com/corundumstudio/socketio/spring/boot/SocketioServerProperties.java
+++ b/src/main/java/com/corundumstudio/socketio/spring/boot/SocketioServerProperties.java
@@ -25,10 +25,17 @@ public class SocketioServerProperties extends Configuration {
 	public static final String PREFIX = "spring.socketio.server";
 
 	/**
+	 * If set to true, then useLinuxNativeEpoll property is passed to SocketIO server as is.
+	 * If set to false and useLinuxNativeEpoll set to true,
+	 * then additional check is performed if epoll library is available on classpath.
+	 */
+	private boolean failIfNativeEpollLibNotPresent = false;
+
+	/**
 	 * Enable Socketio Server.
 	 */
 	private boolean enabled = false;
-	
+
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -37,4 +44,11 @@ public class SocketioServerProperties extends Configuration {
 		this.enabled = enabled;
 	}
 
+	public boolean isFailIfNativeEpollLibNotPresent() {
+		return failIfNativeEpollLibNotPresent;
+	}
+
+	public void setFailIfNativeEpollLibNotPresent(boolean failIfNativeEpollLibNotPresent) {
+		this.failIfNativeEpollLibNotPresent = failIfNativeEpollLibNotPresent;
+	}
 }


### PR DESCRIPTION
If `spring.socketio.server.use-linux-native-epoll=true` is set on non-linux environment, application fails to start because there is no epoll library available. Would be great to make this less strict and still allow app to start and just print warning that it won't use native epoll (just like spring webflux does).
Introduced changes:
if `spring.socketio.server.fail-if-native-epoll-lib-not-present=false` and `spring.socketio.server.use-linux-native-epoll=true` are both set then additional check is made if Epoll is available on target machine. If not, it will just print warning and continue boostraping process with native epoll turned off.